### PR TITLE
Remove validation of the file_path parameter in file_reader

### DIFF
--- a/file_reader/1.0.0/config/config_schema.json
+++ b/file_reader/1.0.0/config/config_schema.json
@@ -7,12 +7,6 @@
                 "properties": {
                     "filepath": {
                         "rules": {
-                            "customRule": [
-                                {
-                                    "errMsg": "Charset restriction to [0-9a-zA-Z:/\\-_/*,\\.]",
-                                    "script": "dx: /^[\\ 0-9a-zA-Z:/\\-_/*,\\.]*$/.test({{$root.log_files[i].filepath}})"
-                                }
-                            ],
                             "required": {
                                 "errMsg": "Common.Pseudo.ValidationText.Required",
                                 "value": true


### PR DESCRIPTION
This parameter had been validating using a simple regexp that doesn't allow specifying absolute paths and other correct windows paths like network shares.

Checking the validity of the path for both Windows and Unix systems simultaneously seems unnecessary in UI since it is almost impossible to check all correct variants using just regexp.  So instead of correcting the regexp - I obliterated it.
Closes #10 
Closes #11