### PR TITLE
update luapower submodule link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "luapower"]
 	path = luapower
-	url = git@github.com:capr/multigit.git
+	url = git@github.com:vxcontrol/multigit.git


### PR DESCRIPTION
luapower mgit repository was updated due to additional .gitignore added on top of original fork.
This commit updates tip of the "luapower" submodule to github.com:vxcontrol/multigit:HEAD.