### PR TITLE
preserve actions list while getting them from callback data

### DIFF
--- a/tests/file_remover_client_spec.lua
+++ b/tests/file_remover_client_spec.lua
@@ -100,7 +100,7 @@ describe('file_remover agent', function()
                     "failed to send file remove action")
                 -- wait for expected result to arrive (in any order)
                 assert.is_true(__mock:expect("event", function(o)
-                        return o.event and o.event.name == "fr_object_file_removed_failed"
+                    return o.event and o.event.name == "fr_object_file_removed_failed"
                 end))
                 assert.is_true(__mock:expect("data",
                     function(o) return o.data and o.data.name == "fr_remove_object_file" end))
@@ -186,7 +186,8 @@ describe('file_remover agent', function()
                     file_path = new_test_file()
                     assert.is_true(file_exists(file_path), "file was not created on FS")
                 end
-                local expected_reason = test_case.create_file and "removed successful" or file_path .. ": No such file or directory"
+                local expected_reason = test_case.create_file and "removed successful" or
+                    file_path .. ": No such file or directory"
                 local expected_uniq = "fr_" ..
                     test_case.type ..
                     "_" .. test_case.subtype ..
@@ -329,6 +330,26 @@ describe('file_remover agent', function()
                     return false
                 end))
         end)
+
+        it('actions list should be preserved in events', function()
+            local test_file_path         = new_test_file(__mock.rand_uuid())
+            local data                   = { data = {}, actions = { "some_action" } }
+            data.data['object.fullpath'] = test_file_path
+            local action_data            = cjson.encode(data)
+
+            assert(__mock:send_action(__mock.mock_token, __mock.module_token, action_data, "fr_remove_object_file"))
+            assert.is_true(__mock:expect("event",
+                function(o)
+                    if o.event and o.event.name == "fr_object_file_removed_successful" then
+                        assert.not_nil(o.event.actions)
+                        assert.equal(2, #o.event.actions)
+                        assert.equal('some_action', o.event.actions[1])
+                        assert.equal('file_remover.fr_remove_object_file', o.event.actions[2])
+                        return true
+                    end
+                    return false
+                end))
+        end)
     end)
 
     describe('file removal bug fixes', function()
@@ -351,4 +372,5 @@ describe('file_remover agent', function()
             assert.is_false(file_exists(test_file_path), "test file was not removed by a module")
         end)
     end)
+
 end)

--- a/utils/protocol/cmodule.lua
+++ b/utils/protocol/cmodule.lua
@@ -176,7 +176,6 @@ cmodule.start = function(action_handlers, background_process)
             event_data.__cid = action_data.__cid
             event_data.uuid = action_data.uuid or make_uuid()
 
-
             -- before sending the event, take list of actions that was already performed and add current action
             local action_full_name = __config.ctx.name .. "." .. action_name
             if glue.indexof(action_full_name, actions) == nil then

--- a/utils/protocol/smodule.lua
+++ b/utils/protocol/smodule.lua
@@ -1,5 +1,4 @@
 local cjson    = require("cjson.safe")
-local glue     = require("glue")
 local protocol = require("protocol/protocol")
 
 require("engine")

--- a/utils/protocol/smodule.lua
+++ b/utils/protocol/smodule.lua
@@ -82,22 +82,6 @@ local function get_agent_src_by_id(id, atype)
     return "", {}
 end
 
-smodule.push_event_for_action = function(agent_id, event_name, action_name, event_data, actions)
-    assert(agent_id ~= nil and agent_id ~= "", "agent id must be defined")
-    assert(event_name ~= nil and event_name ~= "", "event name must be defined")
-    assert(action_name ~= nil and action_name ~= "", "action name must be defined")
-    event_data = event_data or {}
-    actions = actions or {}
-
-    if action_name ~= "" then
-        local action_full_name = __config.ctx.name .. "." .. action_name
-        if glue.indexof(action_full_name, actions) == nil then
-            table.insert(actions, action_full_name)
-        end
-    end
-    smodule.push_event(agent_id, event_name, event_data, actions)
-end
-
 smodule.push_event = function(agent_id, event_name, event_data, actions)
     assert(agent_id ~= nil and agent_id ~= "", "agent id must be defined")
     assert(event_name ~= nil and event_name ~= "", "event name must be defined")


### PR DESCRIPTION
### Description of the Change
The change preserves the "actions" list received in action callback while event is pushed back to a queue, this actions is required to break recursive calls which may happen due to dynamic logic of action-event chains.

### Changelog Entry
> Added - list of actions is being passed to handler functions so it will be possible to analyze history of calls in business logic code (if needed)
> Fixed - missed list of actions in push_event was added

### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
