### PR TITLE
fix importing luacov for tests running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ tmpdir/*
 
 luacov-html
 luacov.*
+!luacov.lua
 coverage-report
 junit.xml

--- a/tests_framework/lua/busted/modules/luacov.lua
+++ b/tests_framework/lua/busted/modules/luacov.lua
@@ -1,0 +1,23 @@
+return function()
+  -- Function to initialize luacov if available
+  local loadLuaCov = function(config)
+    local result, luacov = pcall(require, 'luacov.runner')
+
+    if not result then
+      return nil, 'LuaCov not found on the system, try running without --coverage option, or install LuaCov first'
+    end
+
+    -- call it to start
+    luacov(config)
+
+    -- exclude busted files
+    table.insert(luacov.configuration.exclude, 'busted_bootstrap$')
+    table.insert(luacov.configuration.exclude, 'busted%.')
+    table.insert(luacov.configuration.exclude, 'luassert%.')
+    table.insert(luacov.configuration.exclude, 'say%.')
+    table.insert(luacov.configuration.exclude, 'pl%.')
+    return true
+  end
+
+  return loadLuaCov
+end

--- a/tests_framework/lua/luacov.lua
+++ b/tests_framework/lua/luacov.lua
@@ -1,0 +1,8 @@
+--- Loads `luacov.runner` and immediately starts it.
+-- Useful for launching scripts from the command-line. Returns the `luacov.runner` module.
+-- @class module
+-- @name luacov
+-- @usage lua -lluacov sometest.lua
+local runner = require("luacov.runner")
+runner.init()
+return runner


### PR DESCRIPTION
Running tests according to the [documentation](https://github.com/vxcontrol/soldr-modules/wiki/Unit-testing#tests-starting) gives an error.

Closes https://github.com/vxcontrol/soldr-modules/issues/37

### Description of the Change
Steps to reproduce:
```
git clone git@github.com:vxcontrol/soldr-modules.git
cd soldr-modules
git submodule init
git submodule update
cd luapower/
./mgit clone git@github.com:vxcontrol/soldr-luapower-repos.git
./mgit clone-all

cd soldr-modules

export LUAPOWER_PLATFORM=osx64
export LUA_PATH="$(pwd)/tests_framework/lua/?.lua;$(pwd)/tests_framework/lua/?/init.lua;$(pwd)/luapower/?.lua;$(pwd)/luapower/?/init.lua;$(pwd)/utils/?.lua;$(pwd)/utils/?/init.lua"
export LUA_CPATH="$(pwd)/luapower/bin/$LUAPOWER_PLATFORM/lib?.dylib;$(pwd)/luapower/bin/$LUAPOWER_PLATFORM/clib/?.so;"
export LUA_BIN="$(pwd)/luapower/bin/$LUAPOWER_PLATFORM/luajit-bin"

./tests_framework/lua/bin/busted.$LUAPOWER_PLATFORM.cmd tests/.
```

Expected behaviour:
```
ARG[1] tests/.
...
N successes / 0 failures / 0 errors / 0 pending : 1.0 seconds
```

Actual behaviour:
```
ARG[1] tests/.
/soldr-modules/luapower/bin/osx64/luajit-bin: /soldr-modules/tests_framework/lua/busted/runner.lua:25: module 'busted.modules.luacov' not found:
	no field package.preload['busted.modules.luacov']
	no file '/soldr-modules/tests_framework/lua/busted/modules/luacov.lua'
	no file '/soldr-modules/tests_framework/lua/busted/modules/luacov/init.lua'
	no file '/soldr-modules/luapower/busted/modules/luacov.lua'
	no file '/soldr-modules/luapower/busted/modules/luacov/init.lua'
	no file '/soldr-modules/utils/busted/modules/luacov.lua'
	no file '/soldr-modules/utils/busted/modules/luacov/init.lua'
	no file '/soldr-modules/luapower/bin/osx64/libbusted/modules/luacov.dylib'
	no file '/soldr-modules/luapower/bin/osx64/clib/busted/modules/luacov.so'
	no file '/soldr-modules/luapower/bin/osx64/libbusted.dylib'
	no file '/soldr-modules/luapower/bin/osx64/clib/busted.so'
stack traceback:
	[C]: in function 'require'
	/soldr-modules/tests_framework/lua/busted/runner.lua:25: in function </soldr-modules/tests_framework/lua/busted/runner.lua:11>
	/soldr-modules/tests_framework/lua/bin/busted.lua:12: in main chunk
	[C]: at 0x010fbeb620
```

### Changelog Entry
> Fixed 
Running unit tests according to the documentation https://github.com/vxcontrol/soldr-modules/wiki/Unit-testing#tests-starting

### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
