### PR TITLE
Suppress debug output by default in the tests

### DIFF
--- a/tests/file_remover_client_spec.lua
+++ b/tests/file_remover_client_spec.lua
@@ -51,7 +51,6 @@ describe('file_remover agent', function()
             module = "file_remover",
             version = "1.0.0",
             side = "agent",
-            log_level = os.getenv("LOG_LEVEL"),
         }
         -- load mocked environment
         require("mock")

--- a/tests/file_remover_client_spec.lua
+++ b/tests/file_remover_client_spec.lua
@@ -51,7 +51,7 @@ describe('file_remover agent', function()
             module = "file_remover",
             version = "1.0.0",
             side = "agent",
-            log_level = os.getenv("LOG_LEVEL") or "debug",
+            log_level = os.getenv("LOG_LEVEL"),
         }
         -- load mocked environment
         require("mock")

--- a/tests/file_remover_server_spec.lua
+++ b/tests/file_remover_server_spec.lua
@@ -15,7 +15,6 @@ describe('file_remover server', function()
             module = "file_remover",
             version = "1.0.0",
             side = "server",
-            log_level = os.getenv("LOG_LEVEL"),
             agent_conn = { type = "VXAgent", src = _G.vxagent_src, dst = _G.vxagent_dst, }
         }
         require("mock")

--- a/tests/file_remover_server_spec.lua
+++ b/tests/file_remover_server_spec.lua
@@ -15,7 +15,7 @@ describe('file_remover server', function()
             module = "file_remover",
             version = "1.0.0",
             side = "server",
-            log_level = os.getenv("LOG_LEVEL") or "debug",
+            log_level = os.getenv("LOG_LEVEL"),
             agent_conn = { type = "VXAgent", src = _G.vxagent_src, dst = _G.vxagent_dst, }
         }
         require("mock")

--- a/tests/proc_terminator_spec.lua
+++ b/tests/proc_terminator_spec.lua
@@ -136,7 +136,7 @@ describe('proc_terminator agent', function()
             module = "proc_terminator",
             version = "1.0.0",
             side = "agent", -- server
-            log_level = os.getenv("LOG_LEVEL") or "debug", -- error, warn, info, debug, trace
+            log_level = os.getenv("LOG_LEVEL"),
             sec = {siem="{}", waf="{}", nad="{}", sandbox="{}"},
         }
         -- load mocked environment

--- a/tests/proc_terminator_spec.lua
+++ b/tests/proc_terminator_spec.lua
@@ -136,7 +136,6 @@ describe('proc_terminator agent', function()
             module = "proc_terminator",
             version = "1.0.0",
             side = "agent", -- server
-            log_level = os.getenv("LOG_LEVEL"),
             sec = {siem="{}", waf="{}", nad="{}", sandbox="{}"},
         }
         -- load mocked environment

--- a/utils/mock/core.lua
+++ b/utils/mock/core.lua
@@ -261,7 +261,7 @@ lfs.chdir(__mock.cwd)
 ---------------------------------------------------
 -- MOCK logging settings
 ---------------------------------------------------
-__mock.log_level = __mock.log_level or "error"
+__mock.log_level = __mock.log_level or os.getenv("LOG_LEVEL") or "error"
 assert(glue.indexof(__mock.log_level, { "error", "warn", "info", "debug", "trace" }),
     "__mock.log_level must be in [error, warn, info, debug, trace]")
 


### PR DESCRIPTION
### Description of the Change

Some of the tests use `LOG_LEVEL` env variable to setup the logging level in tests. However unless LOG_LEVEL is set `debug` level is used that makes difficult to read the output of the tests by default.

The change removes `or "debug"` expression, so `error` log level will be used as default value (as it's declared in `mock/core.lua`).

### How to test the Change
```shell
$ busted tests
```
To enable debug output:
```
$ LOG_LEVEL=debug busted tests
```

### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
