### PR TITLE
Tests: move effecting code from description to setup

### DIFF
--- a/tests/file_remover_client_spec.lua
+++ b/tests/file_remover_client_spec.lua
@@ -70,10 +70,11 @@ describe('file_remover agent', function()
     end)
 
     describe('single file removal', function()
-        local src, dst = __mock.mock_token, __mock.module_token
-        local test_file_path = new_test_file()
-
-        local action_data = filepath_to_json('object.fullpath', test_file_path)
+        setup(function()
+            src, dst = __mock.mock_token, __mock.module_token
+            test_file_path = new_test_file()
+            action_data = filepath_to_json('object.fullpath', test_file_path)
+        end)
 
         it('should successfully create file on file system', function()
             assert.is_true(file_exists(test_file_path), "test file is not found")
@@ -109,8 +110,10 @@ describe('file_remover agent', function()
     end)
 
     describe('file that does not exist', function()
-        local src, dst = __mock.mock_token, __mock.module_token
-        local never_existed_file = __mock.tmppath(__mock.rand_uuid() .. ".txt")
+        setup(function()
+            src, dst = __mock.mock_token, __mock.module_token
+            never_existed_file = __mock.tmppath(__mock.rand_uuid() .. ".txt")
+        end)
 
         it('should not be found on the FS', function()
             assert.is_false(file_exists(never_existed_file), "random file somehow exists in FS")
@@ -137,47 +140,49 @@ describe('file_remover agent', function()
     end)
 
     describe('file removal', function()
-        local src, dst = __mock.mock_token, __mock.module_token
-        local test_cases = {
-            {
-                create_file = true,
-                action = "fr_remove_object_file", param = "object.fullpath",
-                type = "object", subtype = "file", result_data = "fr_remove_object_file",
-                result_event = "fr_object_file_removed_successful"
-            },
-            {
-                create_file = true,
-                action = "fr_remove_object_proc_image", param = "object.process.fullpath",
-                type = "object", subtype = "proc_image", result_data = "fr_remove_object_proc_image",
-                result_event = "fr_object_proc_image_removed_successful"
-            },
-            {
-                create_file = true,
-                action = "fr_remove_subject_proc_image", param = "subject.process.fullpath",
-                type = "subject", subtype = "proc_image", result_data = "fr_remove_subject_proc_image",
-                result_event = "fr_subject_proc_image_removed_successful"
-            },
-            {
-                create_file = false,
-                action = "fr_remove_object_file", param = "object.fullpath",
-                type = "object", subtype = "file", result_data = "fr_remove_object_file",
-                result_event = "fr_object_file_removed_failed"
-            },
-            {
-                create_file = false,
-                action = "fr_remove_object_proc_image", param = "object.process.fullpath",
-                type = "object", subtype = "proc_image", result_data = "fr_remove_object_proc_image",
-                result_event = "fr_object_proc_image_removed_failed"
-            },
-            {
-                create_file = false,
-                action = "fr_remove_subject_proc_image", param = "subject.process.fullpath",
-                type = "subject", subtype = "proc_image", result_data = "fr_remove_subject_proc_image",
-                result_event = "fr_subject_proc_image_removed_failed"
-            },
-        }
+        setup(function()
+            src, dst = __mock.mock_token, __mock.module_token
+        end)
 
         it('should be possible to call public actions list', function()
+            local test_cases = {
+                {
+                    create_file = true,
+                    action = "fr_remove_object_file", param = "object.fullpath",
+                    type = "object", subtype = "file", result_data = "fr_remove_object_file",
+                    result_event = "fr_object_file_removed_successful"
+                },
+                {
+                    create_file = true,
+                    action = "fr_remove_object_proc_image", param = "object.process.fullpath",
+                    type = "object", subtype = "proc_image", result_data = "fr_remove_object_proc_image",
+                    result_event = "fr_object_proc_image_removed_successful"
+                },
+                {
+                    create_file = true,
+                    action = "fr_remove_subject_proc_image", param = "subject.process.fullpath",
+                    type = "subject", subtype = "proc_image", result_data = "fr_remove_subject_proc_image",
+                    result_event = "fr_subject_proc_image_removed_successful"
+                },
+                {
+                    create_file = false,
+                    action = "fr_remove_object_file", param = "object.fullpath",
+                    type = "object", subtype = "file", result_data = "fr_remove_object_file",
+                    result_event = "fr_object_file_removed_failed"
+                },
+                {
+                    create_file = false,
+                    action = "fr_remove_object_proc_image", param = "object.process.fullpath",
+                    type = "object", subtype = "proc_image", result_data = "fr_remove_object_proc_image",
+                    result_event = "fr_object_proc_image_removed_failed"
+                },
+                {
+                    create_file = false,
+                    action = "fr_remove_subject_proc_image", param = "subject.process.fullpath",
+                    type = "subject", subtype = "proc_image", result_data = "fr_remove_subject_proc_image",
+                    result_event = "fr_subject_proc_image_removed_failed"
+                },
+            }
             for _, test_case in ipairs(test_cases) do
                 -- create test file
                 local file_path = __mock.tmppath(__mock.rand_uuid() .. ".txt")

--- a/tests/proc_terminator_spec.lua
+++ b/tests/proc_terminator_spec.lua
@@ -167,9 +167,9 @@ describe('proc_terminator agent', function()
     end)
 
     describe('process terminator', function()
-        local src, dst = __mock.mock_token, __mock.module_token
-
         local function kill_process_test(kill_process_action)
+            local src, dst = __mock.mock_token, __mock.module_token
+
             local object_type = select(3, kill_process_action:find("^pt_kill_(.-)_process"))
             local need_kill_subprocess = kill_process_action:match("_tree_") ~= nil
             assert.is_true(object_type ~= nil, "unsupported action")


### PR DESCRIPTION
### Description of the Change

In tests, `describe` block is not supposed to contain any effecting code and can contain only other busted blocks: `describe`, `setup`, `it`... or simple declarative expressions (with no actual action).

Current implementation of the tests include running actions right inside of `describe` blocks that brakes such functionality of busted as `busted --list`, `busted --run=test_name`, etc.

The change moves the code with actual actions inside `setup` blocks.

### How to test the Change

```shell
$ busted --list tests
```

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
